### PR TITLE
Add react-server-dom-webpack dependency

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,10 +6,21 @@
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.8.3",
+    "@redwoodjs/sdk": "0.0.59",
+    "expo": "53.0.0",
+    "next": "15.1.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-router": "7.6.1",
     "react-scripts": "4.0.3",
+    "react-server-dom-parcel": "19.1.0",
+    "react-server-dom-turbopack": "19.1.0",
+    "react-server-dom-webpack": "19.1.0",
+    "waku": "0.22.0",
     "web-vitals": "^1.1.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-rsc": "0.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
This PR adds the `react-server-dom-webpack` dependency to the client package.

## Changes
- Updated client dependencies to include react-server-dom-webpack